### PR TITLE
Increase Max Fields from 50 -> 1000

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,7 +555,7 @@ $(function () {
             });
             $("#age-default-input").val($("#age-default-range").slider("values", 0));
 
-            var max_fields = 50;
+            var max_fields = 1000;
 
 
             // Custom Audience


### PR DESCRIPTION
Currently we set an arbitrary limit of 50 max_fields to limit the character length of the Bid Adjustments API call. There is no limit on the Bid Adjustments API to number of fields in validation calls. The only true limit is 65k characters in the request which allows for significantly more fields to be set.

We are updating to 1000 max_fields for now as most fields are <65 characters long.